### PR TITLE
Add missing GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Tuesdays and Thursdays, 3:00 PM - 4:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🚨 Fix: Add missing GitHub Skills activity

Resolves #6 

### Problem
The GitHub Skills activity announced by the principal was missing from the school activities signup page, preventing students from registering for this time-sensitive program.

### Solution
Added the "GitHub Skills" activity to the activities list with:
- **Description**: Learn practical coding and collaboration skills with GitHub (part of GitHub Certifications program)
- **Schedule**: Tuesdays and Thursdays, 3:00 PM - 4:00 PM  
- **Capacity**: 25 students
- **Status**: Ready for registrations

### Testing
- ✅ Application starts successfully
- ✅ Activity appears in `/activities` API endpoint
- ✅ Student registration functionality works correctly
- ✅ All existing activities remain unaffected

### Timeline
This is time-sensitive as registrations close by the end of this week. Students can now sign up for the GitHub Skills program which will help with college applications.

**Ready for review and merge!** 🎓